### PR TITLE
Optionally preserve whitespace in test cases

### DIFF
--- a/pest-test-gen/tests/csv.pest
+++ b/pest-test-gen/tests/csv.pest
@@ -1,0 +1,3 @@
+field = { (ASCII_DIGIT | "." | "-")+ }
+record = { field ~ ("," ~ field)* }
+file = { SOI ~ NEWLINE? ~ (record ~ NEWLINE)* ~ EOI }

--- a/pest-test-gen/tests/csv_cases/whitespace.txt
+++ b/pest-test-gen/tests/csv_cases/whitespace.txt
@@ -1,0 +1,17 @@
+Test Preserves Trailing Whitespace
+
++++++++++
+11,22
+33,44
++++++++++
+
+(file
+  (record
+    (field: "11")
+    (field: "22")
+  )
+  (record
+    (field: "33")
+    (field: "44")
+  )
+)

--- a/pest-test-gen/tests/tests.rs
+++ b/pest-test-gen/tests/tests.rs
@@ -10,7 +10,7 @@ mod example {
 
 #[pest_tests(super::example::ExampleParser, super::example::Rule, "source_file")]
 #[cfg(test)]
-mod test_cases {}
+mod example_test_cases {}
 
 #[pest_tests(
     super::example::ExampleParser,
@@ -19,4 +19,26 @@ mod test_cases {}
     lazy_static = true
 )]
 #[cfg(test)]
-mod test_cases_lazy_static {}
+mod example_test_cases_lazy_static {}
+
+mod csv {
+    use pest_derive;
+
+    #[derive(pest_derive::Parser)]
+    #[grammar = "tests/csv.pest"]
+    pub struct CsvParser;
+}
+
+#[pest_tests(super::csv::CsvParser, super::csv::Rule, "file", dir = "tests/csv_cases")]
+#[cfg(test)]
+mod csv_test_cases {}
+
+#[pest_tests(
+    super::csv::CsvParser,
+    super::csv::Rule,
+    "file",
+    lazy_static = true,
+    dir = "tests/csv_cases"
+)]
+#[cfg(test)]
+mod csv_test_cases_lazy_static {}

--- a/pest-test/src/model.rs
+++ b/pest-test/src/model.rs
@@ -298,22 +298,26 @@ impl TestCase {
             .ok_or_else(|| ModelError::from_str("Missing code block"))
             .and_then(|pair| assert_rule(pair, Rule::code_block))
             .map(|pair| pair.into_inner())?;
-        code_block
+        let div = code_block
             .next()
             .ok_or_else(|| ModelError::from_str("Missing div"))
-            .and_then(|pair| assert_rule(pair, Rule::div))?;
-        let code = code_block
+            .and_then(|pair| assert_rule(pair, Rule::div))
+            .map(|pair| pair.as_str())?;
+        let mut code = code_block
             .next()
             .ok_or_else(|| ModelError::from_str("Missing code"))
             .and_then(|pair| assert_rule(pair, Rule::code))
-            .map(|pair| pair.as_str().trim().to_owned())?;
+            .map(|pair| pair.as_str())?;
         let expression = inner
             .next()
             .ok_or_else(|| ModelError::from_str("Missing expression"))
             .and_then(|pair| assert_rule(pair, Rule::expression))?;
+        if !div.starts_with('+'){
+            code = code.trim();
+        }
         Ok(TestCase {
             name,
-            code,
+            code: code.to_owned(),
             expression: Expression::try_from_sexpr(expression)?,
         })
     }

--- a/pest-test/src/test.pest
+++ b/pest-test/src/test.pest
@@ -1,6 +1,6 @@
 test_case = { SOI ~ test_name ~ code_block ~ expression ~ EOI }
 test_name = @{ ( !NEWLINE ~ ANY )+ }
-code_block = { PUSH(div) ~ code ~ POP }
+code_block = ${ PUSH(div) ~ code ~ POP }
 div = @{ ( !NEWLINE ~ ANY ){3,} }
 code = @{ ( !PEEK ~ ANY )* }
 expression = { skip? ~ lparen ~ identifier ~ ( sub_expressions | ( colon ~ string ) )? ~ rparen }


### PR DESCRIPTION
Related to #3 

What do you think about something like this? This preserves the existing behavior as a default, but adds an option to use a particular delimiter (I picked `+` but don't feel strongly about it) to signal that you'd like to avoid trimming whitespace at the start/end of the "code" block in the test cases.

```
Sample test

++++++

file,format
requires,terminal
new,line

++++++

(source_file
  ...
)

```