### PR TITLE
Escape terminal value strings when printing diffs

### DIFF
--- a/pest-test/src/model.rs
+++ b/pest-test/src/model.rs
@@ -231,7 +231,7 @@ impl<'a> ExpressionFormatter<'a> {
                 self.write_str(name)?;
                 if let Some(value) = value {
                     self.write_str(": \"")?;
-                    self.write_str(value)?;
+                    self.write_str(&value.escape_default().to_string())?;
                     self.write_char('"')?;
                 }
                 self.write_char(')')?;

--- a/pest-test/src/model.rs
+++ b/pest-test/src/model.rs
@@ -461,6 +461,27 @@ mod tests {
         Ok(())
     }
 
+    const BLANK_LINES: &str = indoc! {r#"
+
+
+"#};
+
+    #[test]
+    fn test_escape_whitespace() -> Result<(), TestError<Rule>> {
+        let mut writer = String::new();
+        let mut formatter = ExpressionFormatter::from_defaults(&mut writer);
+        let expression = Expression::Terminal {
+            name: "blank_lines".to_string(),
+            value: Some(BLANK_LINES.to_string()),
+        };
+        formatter
+            .fmt(&expression)
+            .expect("Error formatting expression");
+        let expected = r#"(blank_lines: "\n\n")"#;
+        assert_eq!(writer, expected);
+        Ok(())
+    }
+
     const TEXT: &str = indoc! {r#"
     My Test
 


### PR DESCRIPTION
@jdidion How would you feel about a change like this?

I suppose it's a matter of taste, but I think:

```
(body_content
    (action
      (fallback_action
        (text: "STEEL")
      )
    )
    (action
      (fallback_action
        (text: "Beer\'s ready!")
      )
    )
    (blank_line: "\n")
  )
```

reads better in the terminal than:


```
 (body_content
    (action
      (fallback_action
        (text: "STEEL")
      )
    )
    (action
      (fallback_action
        (text: "Beer's ready!")
      )
    )
    (blank_line: "
")
  )
```

The unescaped newline character in particular breaks up the flow when reading.

If you agree, I'll see about adding a test case.