### PR TITLE
ci: fix release-plz with crates.io trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Manage Release PRs and Publish Crates
 permissions:
   pull-requests: write
   contents: write
+  id-token: write  # crates.io trusted publishing (OIDC); no CARGO_REGISTRY_TOKEN needed
 
 on:
   push:
@@ -21,9 +22,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: release-plz/action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           


### PR DESCRIPTION
The 'Manage Release PRs and Publish Crates' workflow failed at checkout ('token not supplied') because no token secrets were configured. This switches crates.io auth to trusted publishing (OIDC): adds id-token: write, drops the CARGO_REGISTRY_TOKEN env var, and moves to the renamed release-plz/action.

Requires two one-time setup steps (documented separately): a RELEASE_PLZ_TOKEN GitHub PAT secret for the GitHub-side release PRs/tags, and a crates.io trusted-publisher registration for the pest-test crate.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>